### PR TITLE
Add units (as a comment) to max_workflow_time

### DIFF
--- a/workshop1/2-loading.md
+++ b/workshop1/2-loading.md
@@ -84,7 +84,7 @@ template:
     
   catch_slurm_errors: true
   container_dir: /path/to/containerdir
-  max_workflow_time: 20100
+  max_workflow_time: 20100 # Minutes
   queues: cloud
   send_job_emails: true
   submission_queue: cloud


### PR DESCRIPTION
It took me a while to work out what the units were, so it would be good to include it somewhere to save people time.